### PR TITLE
Fix measurement date mapping for invalid unknown values

### DIFF
--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/measurements/MeasurementToObservationMapperTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/measurements/MeasurementToObservationMapperTest.kt
@@ -1,0 +1,190 @@
+package edu.stanford.bdh.engagehf.bluetooth.measurements
+
+import androidx.health.connect.client.records.BloodPressureRecord
+import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.WeightRecord
+import androidx.health.connect.client.units.Mass
+import androidx.health.connect.client.units.Pressure
+import com.google.common.truth.Truth.assertThat
+import edu.stanford.bdh.engagehf.bluetooth.service.Measurement
+import edu.stanford.bdh.engagehf.bluetooth.service.Measurement.BloodPressure.Flags
+import edu.stanford.bdh.engagehf.bluetooth.service.Measurement.BloodPressure.Status
+import edu.stanford.bdh.engagehf.modules.healthconnectonfhir.RecordToObservationMapper
+import edu.stanford.bdh.engagehf.modules.utils.TimeProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.hl7.fhir.r4.model.Observation
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+class MeasurementToObservationMapperTest {
+    private val recordToObservationMapper: RecordToObservationMapper = mockk()
+    private val timeProvider: TimeProvider = mockk()
+    private val now = Instant.now()
+    private val offset = ZoneOffset.UTC
+
+    private val mapper = MeasurementToObservationMapper(
+        recordToObservationMapper = recordToObservationMapper,
+        timeProvider = timeProvider,
+    )
+
+    @Before
+    fun setup() {
+        every { timeProvider.nowInstant() } returns now
+        every { timeProvider.currentOffset() } returns offset
+    }
+
+    @Test
+    fun `it should map weight correctly`() {
+        // given
+        val date = ZonedDateTime.now()
+        val weightMeasurement = createWeight(weight = 70.5, zonedDateTime = date)
+        val expectedObservation = Observation()
+        val slot = mutableListOf<WeightRecord>()
+        every { recordToObservationMapper.map(capture(slot)) } returns listOf(expectedObservation)
+
+        // when
+        val result = mapper.map(weightMeasurement)
+        val capturedValue = slot.first()
+
+        // then
+        assertThat(capturedValue.weight).isEqualTo(Mass.kilograms(70.5))
+        assertThat(capturedValue.time).isEqualTo(date.toInstant())
+        assertThat(capturedValue.zoneOffset).isEqualTo(offset)
+        assertThat(result.size).isEqualTo(1)
+        assertThat(expectedObservation).isEqualTo(result.first())
+    }
+
+    @Test
+    fun `it should map blood pressure correctly with valid timestamp`() {
+        // given
+        val measurement = createBloodPressure(
+            timestampYear = 2025,
+            timestampMonth = 6,
+            timestampDay = 15,
+            timeStampHour = 10,
+            timeStampMinute = 30,
+        )
+        val expectedTime = LocalDateTime.of(
+            measurement.timestampYear,
+            measurement.timestampMonth,
+            measurement.timestampDay,
+            measurement.timeStampHour,
+            measurement.timeStampMinute,
+            measurement.timeStampSecond
+        ).toInstant(offset)
+        val expectedSamples = HeartRateRecord.Sample(
+            time = expectedTime,
+            beatsPerMinute = measurement.pulseRate.toLong()
+        )
+        val observation = Observation()
+        val slots = mutableListOf<Record>()
+
+        every {
+            recordToObservationMapper.map(capture(slots))
+        } returns listOf(observation)
+
+        // when
+        val result = mapper.map(measurement)
+        val capturedHeartRateRecord = slots.first() as HeartRateRecord
+        val capturedBloodPressureRecord = slots.last() as BloodPressureRecord
+
+        // then
+        assertThat(capturedHeartRateRecord.samples).isEqualTo(listOf(expectedSamples))
+        assertThat(capturedHeartRateRecord.startTime).isEqualTo(expectedTime)
+        assertThat(capturedHeartRateRecord.endTime).isEqualTo(expectedTime)
+        assertThat(capturedHeartRateRecord.startZoneOffset).isEqualTo(offset)
+        assertThat(capturedHeartRateRecord.endZoneOffset).isEqualTo(offset)
+        assertThat(capturedBloodPressureRecord.time).isEqualTo(expectedTime)
+        assertThat(capturedBloodPressureRecord.systolic).isEqualTo(Pressure.millimetersOfMercury(120.0))
+        assertThat(capturedBloodPressureRecord.diastolic).isEqualTo(Pressure.millimetersOfMercury(80.0))
+        assertThat(capturedBloodPressureRecord.zoneOffset).isEqualTo(offset)
+        assertThat(result.size).isEqualTo(2)
+        assertThat(result).containsExactlyElementsIn(listOf(observation, observation))
+    }
+
+    @Test
+    fun `it should map blood pressure with fallback time when timestamp is invalid`() {
+        // given
+        val measurement = createBloodPressure(
+            timestampYear = 0,
+            timestampMonth = 0,
+            timestampDay = 0,
+            timeStampHour = 0,
+            timeStampMinute = 0,
+        )
+        val expectedTime = now
+        val observation = Observation()
+        val slots = mutableListOf<Record>()
+
+        every {
+            recordToObservationMapper.map(capture(slots))
+        } returns listOf(observation)
+
+        // when
+        val result = mapper.map(measurement)
+        val capturedHeartRateRecord = slots.first() as HeartRateRecord
+        val capturedBloodPressureRecord = slots.last() as BloodPressureRecord
+
+        // then
+        assertThat(capturedHeartRateRecord.startTime).isEqualTo(expectedTime)
+        assertThat(capturedHeartRateRecord.endTime).isEqualTo(expectedTime)
+        assertThat(capturedBloodPressureRecord.time).isEqualTo(expectedTime)
+        assertThat(capturedBloodPressureRecord.zoneOffset).isEqualTo(offset)
+        assertThat(result.size).isEqualTo(2)
+        assertThat(result).containsExactlyElementsIn(listOf(observation, observation))
+    }
+
+    private fun createBloodPressure(
+        timestampYear: Int,
+        timestampMonth: Int,
+        timestampDay: Int,
+        timeStampHour: Int,
+        timeStampMinute: Int,
+    ) = Measurement.BloodPressure(
+        flags = Flags(
+            bloodPressureUnitsFlag = true,
+            timeStampFlag = true,
+            pulseRateFlag = true,
+            userIdFlag = true,
+            measurementStatusFlag = true,
+        ),
+        systolic = 120f,
+        diastolic = 80f,
+        meanArterialPressure = 1f,
+        timestampYear = timestampYear,
+        timestampMonth = timestampMonth,
+        timestampDay = timestampDay,
+        timeStampHour = timeStampHour,
+        timeStampMinute = timeStampMinute,
+        timeStampSecond = 0,
+        pulseRate = 100f,
+        userId = 1,
+        measurementStatus = Status(
+            bodyMovementDetectionFlag = true,
+            cuffFitDetectionFlag = true,
+            irregularPulseDetectionFlag = true,
+            pulseRateRangeDetectionFlags = 0,
+            measurementPositionDetectionFlag = true,
+        ),
+    )
+
+    private fun createWeight(
+        weight: Double = 60.0,
+        zonedDateTime: ZonedDateTime? = null,
+        userId: Int? = null,
+        bmi: Double? = null,
+        height: Double? = null,
+    ) = Measurement.Weight(
+        weight = weight,
+        zonedDateTime = zonedDateTime,
+        userId = userId,
+        bmi = bmi,
+        height = height,
+    )
+}

--- a/engagehf-modules/utils/src/main/kotlin/edu/stanford/bdh/engagehf/modules/utils/TimeProvider.kt
+++ b/engagehf-modules/utils/src/main/kotlin/edu/stanford/bdh/engagehf/modules/utils/TimeProvider.kt
@@ -2,10 +2,13 @@ package edu.stanford.bdh.engagehf.modules.utils
 
 import java.time.Instant
 import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import javax.inject.Inject
 
 class TimeProvider @Inject constructor() {
     fun currentTimeMillis(): Long = nowInstant().toEpochMilli()
-    fun nowInstant() = Instant.now()
-    fun nowLocalTime() = LocalTime.now()
+    fun nowInstant(): Instant = Instant.now()
+    fun nowLocalTime(): LocalTime = LocalTime.now()
+    fun currentOffset(): ZoneOffset = ZonedDateTime.now().offset
 }

--- a/engagehf-modules/utils/src/test/kotlin/edu/stanford/bdh/engagehf/modules/utils/TimeProviderTest.kt
+++ b/engagehf-modules/utils/src/test/kotlin/edu/stanford/bdh/engagehf/modules/utils/TimeProviderTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import java.time.Instant
 import java.time.LocalTime
+import java.time.ZonedDateTime
 
 class TimeProviderTest {
     private val provider = TimeProvider()
@@ -50,5 +51,17 @@ class TimeProviderTest {
         assertThat(result.hour).isAtMost(current.hour + threshold)
         assertThat(result.minute).isAtLeast(current.minute)
         assertThat(result.minute).isAtMost(current.minute + threshold)
+    }
+
+    @Test
+    fun `it should indicate correct zone offset`() {
+        // given
+        val expectedOffset = ZonedDateTime.now().offset
+
+        // when
+        val result = provider.currentOffset()
+
+        // then
+        assertThat(result).isEqualTo(expectedOffset)
     }
 }


### PR DESCRIPTION
# *Blood Pressure to observation mapping*

## :recycle: Current situation & Problem
- Map measurement date to now Instant in case of invalid (non-set time yet) device time
- Unit tests valid and invalid values


## :gear: Release Notes
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
