### PR TITLE
Run the Shared Standard Checks Once

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,12 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  actionlint:
-    name: GitHub Actions Workflows
-    uses: SchmiedmayerLab/.github/.github/workflows/actionlint.yml@v0.5
-    permissions:
-      contents: read
-
   dependency_review:
     name: Dependency Review
     if: github.event_name == 'pull_request'
@@ -34,16 +28,3 @@ jobs:
         uses: actions/checkout@v7
       - name: Review Dependency Changes
         uses: actions/dependency-review-action@v5
-
-  reuse:
-    name: REUSE Compliance
-    uses: SchmiedmayerLab/.github/.github/workflows/reuse.yml@v0.5
-    permissions:
-      contents: read
-
-  markdown_links:
-    name: Markdown Links
-    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5
-    permissions:
-      contents: read
-      pull-requests: read


### PR DESCRIPTION
### :recycle: Current situation & Problem

The organization standards workflow already runs the shared REUSE, markdown link and actionlint checks, and this repository calls the same reusable workflows a second time. Every pull request therefore runs each of them twice and reports two checks for the same work, which doubles the cost and lets a transient failure in one copy contradict the other.

No related issue was identified.

### :gear: Release Notes

- Run the shared standard checks once, through the organization standards workflow, and drop this repository's second copy.

### :books: Documentation

No documentation changes are required.

### :white_check_mark: Testing

- `actionlint`
- The checks the organization standards workflow reports are unchanged and remain required to merge

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
